### PR TITLE
feat: german translation

### DIFF
--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -1,9 +1,9 @@
 menu:
   game:
     title: Spiel
-    localVideo: Lokale Datei auswählen
-    fileDrag: Ziehen und Ablegen erkennen
-    marks: Fragezeichen
+    localVideo: Datei auswählen
+    fileDrag: Ziehen und Ablegen
+    marks: Fragezeichen (?)
     share:
       copy: Link kopieren
       open: Link öffnen

--- a/src/locales/de.yml
+++ b/src/locales/de.yml
@@ -1,0 +1,66 @@
+menu:
+  game:
+    title: Spiel
+    localVideo: Lokale Datei auswählen
+    fileDrag: Ziehen und Ablegen erkennen
+    marks: Fragezeichen
+    share:
+      copy: Link kopieren
+      open: Link öffnen
+      copied: Link wurde in die Zwischenablage kopiert
+      error: Link kopieren fehlgeschlagen
+    download: Video herunterladen
+  options:
+    title: Optionen
+    language: Deutsch
+    toggleLanguages: Sprachen
+    squareSize: Feldgröße
+    videoMap:
+      title: Mauspfad
+      move: Mausbewegung
+      left: Linksklick
+      right: Rechtsklick
+      double: Doppelklick
+      opening: Öffnung
+  help:
+    title: Hilfe
+    source: Quellcode
+    bugs: Fehler melden
+    version: Versionsname
+    author:
+      title: Autor
+      blog: Mein Blog
+      domain: Meine Domain
+  exit:
+    title: Beenden
+
+game:
+  upk: Vorabinformation
+  anonymous: Anonym
+
+controlBar:
+  play: Abspielen
+  pause: Pausieren
+  replay: Erneut abspielen
+  displayVideoMap: Mauspfad anzeigen
+  hideVideoMap: Mauspfad ausblenden
+  reset: Neustart
+
+common:
+  loading: Lädt...
+  copied: 'Kopieren erfolgreich: {0}'
+  fileSelect: 'Bitte wählen Sie eine avf/mvf/rmv/rawvf-Datei aus'
+
+error:
+  copy: 'Kopieren fehlgeschlagen: {0}'
+  videoParse: 'Lesefehler: '
+  uriRequest: 'Datenanfragefehler：{0}'
+  invalidStatus: 'Invalider Statuscode：{0}'
+  shareParams: 'Teil-Parameter-Lesefehler: {0}'
+  fileNotPresent: Datei existiert nicht
+  fileNotSelect: Keine Datei ausgewählt oder Datei nicht verfügbar
+  fileTooMany: 'Zu viele Dateien: {0}'
+  fileEmpty: 'Dateiinhalt ist leer: {0}'
+  fileUnsupported: '@:common.fileSelect'
+  fileTooLarge: 'Datei ist größer als 5 MB: {0}'
+  fileReadError: 'Dateilesefehler: {0}'

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -33,6 +33,9 @@ function getDefaultLocale () {
     } else if (/^en\b/i.test(language)) {
       // 英语
       return 'en'
+    } else if (/^de\b/i.test(language)) {
+      // german
+      return 'de'
     }
   }
   // 默认使用英语


### PR DESCRIPTION
German translation!

One note: I translated "video map" as "Mauspfad", which pretty much means "mouse path". From my memory, that's what other clones call it in English as well - I may be wrong though, haven't used them in a while.

But, as an english-speaking user:
 - "mouse path" is the term I expected, and that would have instantly told me what to expect from the UI.
 - I also didn't immediately know what to expect from "video view". In context, I suspected it would probably be that, but had to look at it to confirm.

If you don't want to call it "mouse path" - it contains more than just the path, after all - perhaps just "path", "path view" or "event view" would be a better fit?

In any case, german translations for all candidates rn:
 "path" - "Pfad"
 "path view" - "Pfadansicht"
 "event view" - "Ereignisansicht"
 "video map" - "Videokarte"

